### PR TITLE
Enable compiling SFML from source

### DIFF
--- a/3rdParty/sfml/CMakeLists.txt
+++ b/3rdParty/sfml/CMakeLists.txt
@@ -1,0 +1,12 @@
+include(functions/FetchContent_ExcludeFromAll_backport)
+
+set(SFML_BUILD_WINDOW OFF)
+set(SFML_BUILD_GRAPHICS OFF)
+set(SFML_BUILD_AUDIO OFF)
+
+include(FetchContent)
+FetchContent_Declare_ExcludeFromAll(sfml
+    GIT_REPOSITORY https://github.com/SFML/SFML
+    GIT_TAG 016bea9491ccafc3529019fe1d403885a8b3a6ae
+)
+FetchContent_MakeAvailable_ExcludeFromAll(sfml)

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -275,3 +275,8 @@ if(GPERF)
   find_package(Gperftools REQUIRED)
   message("INFO: ${GPERFTOOLS_LIBRARIES}")
 endif()
+
+find_package(SFML 3.0 COMPONENTS Network CONFIG QUIET)
+if(NOT SFML_FOUND)
+  add_subdirectory(3rdParty/sfml)
+endif()

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -677,6 +677,7 @@ target_link_dependencies(libdevilutionx PUBLIC
   libsmackerdec
   ${LUA_LIBRARIES}
   sol2::sol2
+  SFML::Network
   tl
   unordered_dense::unordered_dense
   libdevilutionx_assets
@@ -821,7 +822,3 @@ target_include_directories(libdevilutionx PUBLIC "$<BUILD_INTERFACE:${PROTO_BINA
 include_directories("${PROTO_BINARY_DIR}/dapi/Backend/Messages")
 
 target_include_directories(libdevilutionx PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/dapi/Backend/DAPIBackendCore")
-
-find_package(SFML COMPONENTS Network CONFIG REQUIRED)
-
-target_link_libraries(libdevilutionx PUBLIC SFML::Network)


### PR DESCRIPTION
This seems to work on Linux and should still be finding the vcpkg library via `find_package()`.